### PR TITLE
V1.0.0.3 : Add support in driver to create device using device_create as register_chrdev_region is not supported in newer linux kernel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-obj-m := chardriver.o
-chardriver-objs := cdriver_init.o cdriver.o
+TARGET = chardriver
+
+obj-m := $(TARGET).o
+$(TARGET)-objs := cdriver_init.o cdriver.o
 
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules

--- a/cdriver.c
+++ b/cdriver.c
@@ -4,7 +4,9 @@
 #include <linux/moduleparam.h>    // Kernel module param
 
 #include <linux/cdev.h>
+#include <linux/fs.h>
 
+#include "prototypes.h"
 /*
  * We need to include our licence in the module during compilation.
  * Otherwise module will fail with error saying that kernel taint because of untrusted license.
@@ -17,24 +19,46 @@ MODULE_DESCRIPTION("This is just a Char driver");
 
 static char *name = "cvijay";
 module_param(name, charp, S_IRUSR);
+unsigned int major=117, minor=1;
 
-int cdriver_alloc(struct cdev **);
+struct cdev *cdev = NULL;
+static const struct file_operations cdriver_fops = {
+	.owner = THIS_MODULE,
+	.open  = cdriver_open,
+	.release = cdriver_release,
+	.read = cdriver_read,
+	.write = cdriver_write,
+};
 
 static int __init cdriver_init(void) {
 
-	struct cdev *cdev = NULL;
+	int rc;
+	dev_t dev = 0;
+	rc = cdriver_alloc(&cdev);
+	if (!rc) {
+		dev = MKDEV(major, minor);
+		printk(KERN_INFO "chardriver :dev id :%d\n", dev);
 
-	printk(KERN_ERR "cdriver init\n");
-	cdriver_alloc(&cdev);
+		cdev->owner = THIS_MODULE;
+		cdev->dev = dev;
+		cdev_init(cdev, &cdriver_fops);
+		printk(KERN_INFO "CDEV Initialized\n");
 
-	if (cdev) cdev_del(cdev);
-
-	return 0;
+		rc = cdev_add(cdev, dev, minor);
+		if (rc == 0) { 
+			printk(KERN_INFO "char device regiestered with kernel :%d\n", dev);
+			return 0;
+		}
+		printk(KERN_ERR "cdev registration with kernel failed rc :0x%x\n",rc);
+		cdev_del(cdev);
+	}
+	return -1;
 }
 
 static void __exit cdriver_exit(void) {
 
-	printk(KERN_ALERT "cdriver exit\n");
+	if (cdev) cdev_del(cdev);
+	printk(KERN_INFO "cdev with dev id :%d unloaded\n", cdev->dev);
 	return;
 }
 

--- a/cdriver.c
+++ b/cdriver.c
@@ -2,6 +2,7 @@
 #include <linux/module.h>         // Core header for loading LKMs into the kernel
 #include <linux/kernel.h>         // Contains types, macros, functions(printk) for the kernel
 #include <linux/moduleparam.h>    // Kernel module param
+#include <linux/version.h>
 
 #include <linux/cdev.h>
 #include <linux/fs.h>
@@ -19,7 +20,7 @@ MODULE_DESCRIPTION("This is just a Char driver");
 
 static char *name = "cvijay";
 module_param(name, charp, S_IRUSR);
-unsigned int major=117, minor=1;
+unsigned int major, minor=1, count=1;
 
 struct cdev *cdev = NULL;
 static const struct file_operations cdriver_fops = {
@@ -32,13 +33,23 @@ static const struct file_operations cdriver_fops = {
 
 static int __init cdriver_init(void) {
 
-	int rc;
+	int rc=0;
 	dev_t dev = 0;
 	rc = cdriver_alloc(&cdev);
 	if (!rc) {
-		dev = MKDEV(major, minor);
-		printk(KERN_INFO "chardriver :dev id :%d\n", dev);
-
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,0)
+		rc = alloc_chrdev_region(&dev, minor, count, name); 
+		if (rc) {
+			printk(KERN_ERR "%s char device allocation failed\n", name);
+			goto del_cdev;
+		}
+		rc = register_chrdev_region(dev, count, name);
+		if (rc) {
+			printk(KERN_ERR "%s char device registeration failed\n", name);
+			goto del_cdev;
+		}
+#else
+#endif
 		cdev->owner = THIS_MODULE;
 		cdev->dev = dev;
 		cdev_init(cdev, &cdriver_fops);
@@ -46,9 +57,11 @@ static int __init cdriver_init(void) {
 
 		rc = cdev_add(cdev, dev, minor);
 		if (rc == 0) { 
-			printk(KERN_INFO "char device regiestered with kernel :%d\n", dev);
+			printk(KERN_INFO " %s char device is up. Major no :%u minor :%u\n",
+					name, MAJOR(dev), MINOR(dev));
 			return 0;
 		}
+del_cdev:
 		printk(KERN_ERR "cdev registration with kernel failed rc :0x%x\n",rc);
 		cdev_del(cdev);
 	}
@@ -57,8 +70,10 @@ static int __init cdriver_init(void) {
 
 static void __exit cdriver_exit(void) {
 
-	if (cdev) cdev_del(cdev);
-	printk(KERN_INFO "cdev with dev id :%d unloaded\n", cdev->dev);
+	if (cdev) {
+		cdev_del(cdev);  //Unregister from kernel first to aviod kernel operations.
+		unregister_chrdev_region(cdev->dev, count);
+	}
 	return;
 }
 

--- a/cdriver.c
+++ b/cdriver.c
@@ -4,6 +4,7 @@
 #include <linux/moduleparam.h>    // Kernel module param
 #include <linux/version.h>
 
+#include <linux/device.h>
 #include <linux/cdev.h>
 #include <linux/fs.h>
 
@@ -18,11 +19,16 @@ MODULE_VERSION("23.12.2016");
 MODULE_DESCRIPTION("This is just a Char driver");
 
 
-static char *name = "cvijay";
+static char *name = "char_device", *class_name = "char_class";
 module_param(name, charp, S_IRUSR);
+
+static struct class *cclass;
+static struct device *cdevice;
+
+dev_t dev;
 unsigned int major, minor=1, count=1;
 
-struct cdev *cdev = NULL;
+struct cdev *cdev;
 static const struct file_operations cdriver_fops = {
 	.owner = THIS_MODULE,
 	.open  = cdriver_open,
@@ -34,21 +40,54 @@ static const struct file_operations cdriver_fops = {
 static int __init cdriver_init(void) {
 
 	int rc=0;
-	dev_t dev = 0;
 	rc = cdriver_alloc(&cdev);
 	if (!rc) {
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,0)
 		rc = alloc_chrdev_region(&dev, minor, count, name); 
 		if (rc) {
 			printk(KERN_ERR "%s char device allocation failed\n", name);
 			goto del_cdev;
 		}
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,16)
 		rc = register_chrdev_region(dev, count, name);
 		if (rc) {
 			printk(KERN_ERR "%s char device registeration failed\n", name);
 			goto del_cdev;
 		}
 #else
+/* This is a #define to keep the compiler from merging different
+ * instances of the __key variable
+ * #define class_create(owner, name)
+ * ({
+ *       static struct lock_class_key __key;
+ *       __class_create(owner, name, &__key);
+ * })
+ * extern void class_destroy(struct class *cls);
+ */
+
+//new class will be created under /sys/class/
+		cclass = class_create(THIS_MODULE, class_name);
+		if (cclass==NULL) {
+			printk(KERN_ALERT "Class creation failed\n");
+			goto del_cdev;
+		} else {
+			printk (KERN_INFO "Class created\n");
+		}
+/*
+ * struct device *device_create(struct class *cls, struct device *parent,
+ *                            dev_t devt, void *drvdata,
+ *                            const char *fmt, ...);
+ *  extern void device_destroy(struct class *cls, dev_t devt);
+ */
+
+//New device (char device) will be created in /dev/
+		cdevice = device_create(cclass, NULL, dev, NULL, name, NULL);
+		if (cdevice) {
+			printk(KERN_INFO "Device creation success for cvijay, major :%u minor :%u\n",
+					MAJOR(dev), MINOR(dev));
+		} else {
+			printk(KERN_ALERT "Device creation failed\n");
+			goto del_class;
+		}
 #endif
 		cdev->owner = THIS_MODULE;
 		cdev->dev = dev;
@@ -56,11 +95,14 @@ static int __init cdriver_init(void) {
 		printk(KERN_INFO "CDEV Initialized\n");
 
 		rc = cdev_add(cdev, dev, minor);
-		if (rc == 0) { 
+		if (rc == 0) {
 			printk(KERN_INFO " %s char device is up. Major no :%u minor :%u\n",
 					name, MAJOR(dev), MINOR(dev));
 			return 0;
 		}
+		device_destroy(cclass, dev);
+del_class:
+		class_destroy(cclass);
 del_cdev:
 		printk(KERN_ERR "cdev registration with kernel failed rc :0x%x\n",rc);
 		cdev_del(cdev);
@@ -70,10 +112,14 @@ del_cdev:
 
 static void __exit cdriver_exit(void) {
 
-	if (cdev) {
-		cdev_del(cdev);  //Unregister from kernel first to aviod kernel operations.
-		unregister_chrdev_region(cdev->dev, count);
-	}
+	if(cclass)
+		class_destroy(cclass);
+	if(cdevice)
+		device_destroy(cclass, dev);
+		cdev_del(cdev);
+	if (dev)
+		unregister_chrdev_region(dev, count);
+
 	return;
 }
 

--- a/cdriver_init.c
+++ b/cdriver_init.c
@@ -8,7 +8,7 @@ MODULE_LICENSE("GPL");
 int cdriver_alloc(struct cdev **cdev) {
 
 	*cdev = cdev_alloc();
-	if (!(*cdev)) {
+	if (*cdev==NULL) {
 		printk(KERN_ERR "cdev allocation failed...\n");
 		return -1;
 	}
@@ -39,6 +39,5 @@ ssize_t cdriver_read(struct file *cfile, char __user *crbuf, size_t size, loff_t
 
 ssize_t cdriver_write(struct file *cfile, const char __user *crbuf, size_t size, loff_t *croffset) {
 	printk("write .... size :%d\n", size);
-	printk(KERN_INFO "%s", crbuf);
 	return 0;
 }

--- a/cdriver_init.c
+++ b/cdriver_init.c
@@ -1,11 +1,10 @@
 #include <linux/cdev.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
-
+#include "prototypes.h"
 
 MODULE_LICENSE("GPL"); 
 
-int cdriver_alloc(struct cdev **);
 int cdriver_alloc(struct cdev **cdev) {
 
 	*cdev = cdev_alloc();
@@ -13,10 +12,8 @@ int cdriver_alloc(struct cdev **cdev) {
 		printk(KERN_ERR "cdev allocation failed...\n");
 		return -1;
 	}
-	printk(KERN_ALERT "function called\n");
 	return 0;
 }
-
 /*
  * EXPORT_SYMBOL(cdriver_alloc);
  * 
@@ -25,3 +22,23 @@ int cdriver_alloc(struct cdev **cdev) {
  * that means symbol is not exported into this file.
  * all symbols are available across multiple files and modules(dependency modules).
  */
+int cdriver_open(struct inode *cinode, struct file *cfile) { 
+	printk("open ...\n");
+	return 0;
+}
+
+int cdriver_release(struct inode *cinode, struct file *cfile) {
+	printk("release ...\n");
+	return 0;
+}
+
+ssize_t cdriver_read(struct file *cfile, char __user *crbuf, size_t size, loff_t *croffset) {
+	printk("read .... size :%d\n", size);
+	return 0;
+}
+
+ssize_t cdriver_write(struct file *cfile, const char __user *crbuf, size_t size, loff_t *croffset) {
+	printk("write .... size :%d\n", size);
+	printk(KERN_INFO "%s", crbuf);
+	return 0;
+}

--- a/prototypes.h
+++ b/prototypes.h
@@ -1,0 +1,5 @@
+int cdriver_alloc(struct cdev **);
+ssize_t cdriver_read(struct file *, char __user *, size_t, loff_t *);
+ssize_t cdriver_write(struct file *, const char __user *, size_t, loff_t *);
+int cdriver_open (struct inode *, struct file *);
+int cdriver_release (struct inode *, struct file *);


### PR DESCRIPTION
To create a char device interface under /dev/, register_chrdev_region api is supported upto 2.4 kernel.
From 2.6 kernel or later, added support to create device using device_create api.
Added support in the driver for both 2.4 kernel and newer kernel.

http://stackoverflow.com/questions/41320939/where-do-char-device-appear-after-cdev-add-registers-successfully-with-major-o/41327360?noredirect=1#comment69861733_41327360
