### PR TITLE
v1.0.0.4 : Unload module causing NULL POINTER REFERENCE in kernel

### DIFF
--- a/cdriver.c
+++ b/cdriver.c
@@ -112,14 +112,10 @@ del_cdev:
 
 static void __exit cdriver_exit(void) {
 
-	if(cclass)
-		class_destroy(cclass);
-	if(cdevice)
-		device_destroy(cclass, dev);
-		cdev_del(cdev);
-	if (dev)
-		unregister_chrdev_region(dev, count);
-
+	device_destroy(cclass, dev);
+	class_destroy(cclass);
+	cdev_del(cdev);
+	unregister_chrdev_region(dev, count);
 	return;
 }
 


### PR DESCRIPTION
Root cause:
         In unload path,
         we are trying to destroy device after class has been destroyed.
         Since device is listed under class, we should destroy device first.
         Sequence should be :
                            1. destroy device ( ls /dev/char_device)
                            2. destroy class  ( ls /sys/class/char_class)
                            3. destroy driver memory resources.