### PR TITLE
v1.0.0.5 : Kernel hooked up after writing data to char device using echo

### DIFF
--- a/cdriver_init.c
+++ b/cdriver_init.c
@@ -39,5 +39,5 @@ ssize_t cdriver_read(struct file *cfile, char __user *crbuf, size_t size, loff_t
 
 ssize_t cdriver_write(struct file *cfile, const char __user *crbuf, size_t size, loff_t *croffset) {
 	printk("write .... size :%d\n", size);
-	return 0;
+	return size;
 }


### PR DESCRIPTION
Root cause : Wrong return value from write function.
             write system call should return how many bytes of data has been
                   processed.
             Kernel will invoke write utill all bytes were processed.
             We are always returing non zero value in write callback, where kernel
                hooked up.
