### PR TITLE
BUGID: ghi11

### DIFF
--- a/kernel_concepts/task_ioctl.c
+++ b/kernel_concepts/task_ioctl.c
@@ -23,7 +23,7 @@ struct task_struct *task;
  */
 
 enum state {
-	KTHREAD_STOP,
+	KTHREAD_STOP = 10,
 	KTHREAD_CREATE,
 	KTHREAD_START,
 	KTHREAD_DELAY,


### PR DESCRIPTION
	* Workaround is to use IOCTL values from 10 in the enum.