### PR TITLE
Bugid.ghi018

### DIFF
--- a/kernel_concepts/task_ioctl.c
+++ b/kernel_concepts/task_ioctl.c
@@ -136,8 +136,8 @@ static int __init task1_init(void)
 		memset(&drv, 0, sizeof(drv));
 		memcpy(drv.name, "mythread1", sizeof("mythread1"));
 		drv.thread_stopped = true;
-		sema_init(&drv.slock, 1);
-		down(&drv.slock);
+		sema_init(&drv.slock, 0);
+		//down(&drv.slock);
 	} else {
 		pr_info("Misc Char driver registerion failed with error [%d]",
 				ret);


### PR DESCRIPTION
Merge :    
This is enhancement.

		Initialize binary semaphore with 0 instead 1.
		This will let the kernel thread to sleep at the first down call.
		We do not need to down the semaphore in the driver initialization.